### PR TITLE
ML - Add DELETE endpoint for a specific record in UCSBOrganization table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,6 +35,26 @@ public class UCSBOrganizationController extends ApiController {
   @GetMapping("/all")
   public Iterable<UCSBOrganization> allUCSBOrganizations() {
     return ucsbOrganizationRepository.findAll();
+  }
+
+  /**
+   * Delete a UCSBOrganization. Accessible only to users with the role "ROLE_ADMIN".
+   *
+   * @param id organization code (primary key)
+   * @return a message indicating the organization was deleted
+   */
+  @Operation(summary = "Delete a UCSBOrganization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteUCSBOrganization(
+      @Parameter(name = "id") @RequestParam(name = "id") String id) {
+    UCSBOrganization org =
+        ucsbOrganizationRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
+
+    ucsbOrganizationRepository.delete(org);
+    return genericMessage("UCSBOrganization with id %s deleted".formatted(id));
   }
 
   /**

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -36,7 +36,7 @@ public class UCSBOrganizationController extends ApiController {
   public Iterable<UCSBOrganization> allUCSBOrganizations() {
     return ucsbOrganizationRepository.findAll();
   }
-  
+
   /**
    * Get a single UCSBOrganization by id
    *
@@ -54,7 +54,7 @@ public class UCSBOrganizationController extends ApiController {
     return org;
   }
 
-     /**
+  /**
    * Delete a UCSBOrganization. Accessible only to users with the role "ROLE_ADMIN".
    *
    * @param id organization code (primary key)
@@ -65,8 +65,10 @@ public class UCSBOrganizationController extends ApiController {
   @DeleteMapping("")
   public Object deleteUCSBOrganization(
       @Parameter(name = "id") @RequestParam(name = "id") String id) {
-    UCSBOrganization org = ucsbOrganizationRepository.findById(id)
-        .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
+    UCSBOrganization org =
+        ucsbOrganizationRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
     ucsbOrganizationRepository.delete(org);
     return genericMessage("UCSBOrganization with id %s deleted".formatted(id));
   }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -55,7 +55,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
         .perform(delete("/api/UCSBOrganization").param("id", "ZPRC").with(csrf()))
         .andExpect(status().is(403));
   }
-  
+
   @Test
   public void logged_out_users_cannot_get_by_id() throws Exception {
     mockMvc.perform(get("/api/UCSBOrganization").param("id", "ZPRC")).andExpect(status().is(403));

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,11 +1,13 @@
 package edu.ucsb.cs156.example.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,6 +19,8 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -43,6 +47,13 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   @Test
   public void logged_in_users_can_get_all() throws Exception {
     mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().is(200));
+  }
+
+  @Test
+  public void logged_out_users_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/UCSBOrganization").param("id", "ZPRC").with(csrf()))
+        .andExpect(status().is(403));
   }
 
   // Authorization tests for /api/UCSBOrganization/post
@@ -145,5 +156,54 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(org);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_an_existing_ucsb_organization() throws Exception {
+    // arrange
+    UCSBOrganization org =
+        UCSBOrganization.builder()
+            .orgCode("ZPRC")
+            .orgTranslationShort("ZPRC short")
+            .orgTranslation("ZPRC full translation")
+            .inactive(false)
+            .build();
+
+    when(ucsbOrganizationRepository.findById(eq("ZPRC"))).thenReturn(Optional.of(org));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/UCSBOrganization").param("id", "ZPRC").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(ucsbOrganizationRepository, times(1)).findById("ZPRC");
+    verify(ucsbOrganizationRepository, times(1)).delete(any());
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("UCSBOrganization with id ZPRC deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_delete_non_existant_ucsb_organization_and_gets_right_error_message()
+      throws Exception {
+    // arrange
+    when(ucsbOrganizationRepository.findById(eq("NOPE"))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/UCSBOrganization").param("id", "NOPE").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(ucsbOrganizationRepository, times(1)).findById("NOPE");
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("UCSBOrganization with id NOPE not found", json.get("message"));
   }
 }


### PR DESCRIPTION
Add DELETE endpoint to delete a specific record in UCSBOrganization
Handles errors properly with correct message
Full test coverage for Jacoco
Full mutation test coverage for Pitest

Closes #18 