### PR TITLE
ML - Add PUT (edit) endpoint for a single record in UCSBOrganization

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -40,7 +40,6 @@ public class UCSBOrganizationController extends ApiController {
     return ucsbOrganizationRepository.findAll();
   }
 
-
   /**
    * Update a single UCSBOrganization. Accessible only to users with the role "ROLE_ADMIN".
    *
@@ -104,8 +103,8 @@ public class UCSBOrganizationController extends ApiController {
     ucsbOrganizationRepository.delete(org);
     return genericMessage("UCSBOrganization with id %s deleted".formatted(id));
   }
-  
-  
+
+  /**
    * Create a new UCSBOrganization
    *
    * @param orgCode organization code (primary key)

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,15 +1,19 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,6 +37,34 @@ public class UCSBOrganizationController extends ApiController {
   @GetMapping("/all")
   public Iterable<UCSBOrganization> allUCSBOrganizations() {
     return ucsbOrganizationRepository.findAll();
+  }
+
+  /**
+   * Update a single UCSBOrganization. Accessible only to users with the role "ROLE_ADMIN".
+   *
+   * @param id organization code (primary key)
+   * @param incoming the new organization contents (orgCode is ignored)
+   * @return the updated organization object
+   */
+  @Operation(summary = "Update a single ucsb organization")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public UCSBOrganization updateUCSBOrganization(
+      @Parameter(name = "id") @RequestParam(name = "id") String id,
+      @RequestBody @Valid UCSBOrganization incoming) {
+
+    UCSBOrganization org =
+        ucsbOrganizationRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, id));
+
+    org.setOrgTranslationShort(incoming.getOrgTranslationShort());
+    org.setOrgTranslation(incoming.getOrgTranslation());
+    org.setInactive(incoming.getInactive());
+
+    ucsbOrganizationRepository.save(org);
+
+    return org;
   }
 
   /**

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -50,7 +50,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   public void logged_in_users_can_get_all() throws Exception {
     mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().is(200));
   }
-  
+
   @Test
   public void logged_out_users_cannot_put() throws Exception {
     mockMvc
@@ -75,7 +75,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   public void logged_out_users_cannot_get_by_id() throws Exception {
     mockMvc.perform(get("/api/UCSBOrganization").param("id", "ZPRC")).andExpect(status().is(403));
   }
-  
+
   @Test
   public void logged_out_users_cannot_post() throws Exception {
     mockMvc
@@ -239,7 +239,7 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
   }
-  
+
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
   public void admin_can_edit_an_existing_ucsb_organization() throws Exception {
@@ -367,3 +367,4 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("UCSBOrganization with id NOPE not found", json.get("message"));
   }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edu.ucsb.cs156.example.ControllerTestCase;
@@ -17,9 +18,12 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -43,6 +47,19 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
   @Test
   public void logged_in_users_can_get_all() throws Exception {
     mockMvc.perform(get("/api/UCSBOrganization/all")).andExpect(status().is(200));
+  }
+
+  @Test
+  public void logged_out_users_cannot_put() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/UCSBOrganization")
+                .param("id", "ZPRC")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content("{}")
+                .with(csrf()))
+        .andExpect(status().is(403));
   }
 
   // Authorization tests for /api/UCSBOrganization/post
@@ -70,6 +87,20 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 .param("orgTranslationShort", "ZPRC short")
                 .param("orgTranslation", "ZPRC full translation")
                 .param("inactive", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_put() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/UCSBOrganization")
+                .param("id", "ZPRC")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content("{}")
                 .with(csrf()))
         .andExpect(status().is(403));
   }
@@ -145,5 +176,84 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(org);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_ucsb_organization() throws Exception {
+    // arrange
+    UCSBOrganization orgOrig =
+        UCSBOrganization.builder()
+            .orgCode("ZPRC")
+            .orgTranslationShort("ZPRC short")
+            .orgTranslation("ZPRC full translation")
+            .inactive(false)
+            .build();
+
+    UCSBOrganization orgEdited =
+        UCSBOrganization.builder()
+            .orgCode("ZPRC")
+            .orgTranslationShort("ZPRC short edited")
+            .orgTranslation("ZPRC full translation edited")
+            .inactive(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(orgEdited);
+
+    when(ucsbOrganizationRepository.findById(eq("ZPRC"))).thenReturn(Optional.of(orgOrig));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/UCSBOrganization")
+                    .param("id", "ZPRC")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(ucsbOrganizationRepository, times(1)).findById("ZPRC");
+    verify(ucsbOrganizationRepository, times(1)).save(orgEdited);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_ucsb_organization_that_does_not_exist() throws Exception {
+    // arrange
+    UCSBOrganization orgEdited =
+        UCSBOrganization.builder()
+            .orgCode("NOPE")
+            .orgTranslationShort("short edited")
+            .orgTranslation("full edited")
+            .inactive(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(orgEdited);
+
+    when(ucsbOrganizationRepository.findById(eq("NOPE"))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/UCSBOrganization")
+                    .param("id", "NOPE")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(ucsbOrganizationRepository, times(1)).findById("NOPE");
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("UCSBOrganization with id NOPE not found", json.get("message"));
   }
 }


### PR DESCRIPTION
Added PUT /api/UCSBOrganization?id=<orgCode>
It looks up the existing record by id, updates:
- orgTranslationShort
- orgTranslation
- inactive

If not found → throws EntityNotFoundException (404)

Auth tests: logged out and regular user cannot PUT (403)
Happy path: admin can PUT and gets updated JSON back
Not found: admin PUT on missing id returns 404 + correct message

100% for pitest and jacoco

Closes #17 