### PR TITLE
Add HelpRequest put endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -6,6 +6,7 @@ import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -52,6 +55,35 @@ public class HelpRequestController extends ApiController {
         helpRequestRepository
             .findById(id)
             .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+    return helpRequest;
+  }
+
+  /**
+   * Update a single HelpRequest
+   *
+   * @param id the id of the HelpRequest
+   * @param incoming the new HelpRequest values
+   * @return the updated HelpRequest
+   */
+  @Operation(summary = "Update a single help request")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public HelpRequest updateHelpRequest(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid HelpRequest incoming) {
+    HelpRequest helpRequest =
+        helpRequestRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+    helpRequest.setRequesterEmail(incoming.getRequesterEmail());
+    helpRequest.setTeamId(incoming.getTeamId());
+    helpRequest.setTableOrBreakoutRoom(incoming.getTableOrBreakoutRoom());
+    helpRequest.setRequestTime(incoming.getRequestTime());
+    helpRequest.setExplanation(incoming.getExplanation());
+    helpRequest.setSolved(incoming.getSolved());
+
+    helpRequestRepository.save(helpRequest);
 
     return helpRequest;
   }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edu.ucsb.cs156.example.ControllerTestCase;
@@ -23,6 +24,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -82,6 +84,35 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                 .param("requestTime", "2026-04-25T16:00:00")
                 .param("explanation", "Need help with Dokku")
                 .param("solved", "false")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  // Authorization tests for /api/HelpRequest PUT
+
+  @Test
+  public void logged_out_users_cannot_put() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/HelpRequest")
+                .param("id", "7")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content("{}")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_put() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/HelpRequest")
+                .param("id", "7")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content("{}")
                 .with(csrf()))
         .andExpect(status().is(403));
   }
@@ -224,5 +255,111 @@ public class HelpRequestControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(helpRequest);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_help_request() throws Exception {
+    // arrange
+    LocalDateTime originalRequestTime = LocalDateTime.parse("2026-04-25T16:00:00");
+    LocalDateTime editedRequestTime = LocalDateTime.parse("2026-04-25T16:30:00");
+
+    HelpRequest helpRequestOriginal =
+        HelpRequest.builder()
+            .id(7L)
+            .requesterEmail("student1@ucsb.edu")
+            .teamId("team01")
+            .tableOrBreakoutRoom("4")
+            .requestTime(originalRequestTime)
+            .explanation("Need help with Dokku")
+            .solved(false)
+            .build();
+
+    HelpRequest helpRequestEdited =
+        HelpRequest.builder()
+            .id(99L)
+            .requesterEmail("student2@ucsb.edu")
+            .teamId("team02")
+            .tableOrBreakoutRoom("Breakout room 2")
+            .requestTime(editedRequestTime)
+            .explanation("Need help with tests")
+            .solved(true)
+            .build();
+
+    HelpRequest expectedHelpRequest =
+        HelpRequest.builder()
+            .id(7L)
+            .requesterEmail("student2@ucsb.edu")
+            .teamId("team02")
+            .tableOrBreakoutRoom("Breakout room 2")
+            .requestTime(editedRequestTime)
+            .explanation("Need help with tests")
+            .solved(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(helpRequestEdited);
+
+    when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.of(helpRequestOriginal));
+    when(helpRequestRepository.save(eq(expectedHelpRequest))).thenReturn(expectedHelpRequest);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/HelpRequest")
+                    .param("id", "7")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(helpRequestRepository, times(1)).findById(eq(7L));
+    verify(helpRequestRepository, times(1)).save(expectedHelpRequest);
+    String expectedJson = mapper.writeValueAsString(expectedHelpRequest);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_help_request_that_does_not_exist() throws Exception {
+    // arrange
+    LocalDateTime editedRequestTime = LocalDateTime.parse("2026-04-25T16:30:00");
+
+    HelpRequest helpRequestEdited =
+        HelpRequest.builder()
+            .requesterEmail("student2@ucsb.edu")
+            .teamId("team02")
+            .tableOrBreakoutRoom("Breakout room 2")
+            .requestTime(editedRequestTime)
+            .explanation("Need help with tests")
+            .solved(true)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(helpRequestEdited);
+
+    when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/HelpRequest")
+                    .param("id", "7")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(helpRequestRepository, times(1)).findById(eq(7L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("HelpRequest with id 7 not found", json.get("message"));
   }
 }


### PR DESCRIPTION
## Summary
- Add PUT /api/HelpRequest?id=... endpoint for editing one HelpRequest
- Preserve the id from the URL and update editable fields from the JSON request body
- Add auth, success, and not-found controller tests

Depends on #56. Closes #35 once this branch is retargeted/merged to main.

## Verification
- mvn -q -Dtest=HelpRequestControllerTests test
- mvn -q test jacoco:report
- mvn -q test pitest:mutationCoverage (135 mutations generated, 135 killed, 100% test strength)
- mvn -q git-code-format:validate-code-format