### PR TITLE
Add ArticlesController with GET /all and POST /post endpoints

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -1,0 +1,80 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for Articles */
+@Tag(name = "Articles")
+@RequestMapping("/api/Articles")
+@RestController
+@Slf4j
+public class ArticlesController extends ApiController {
+
+  @Autowired ArticlesRepository articlesRepository;
+
+  /**
+   * List all Articles
+   *
+   * @return an iterable of Articles
+   */
+  @Operation(summary = "List all articles")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<Articles> allArticles() {
+    Iterable<Articles> articles = articlesRepository.findAll();
+    return articles;
+  }
+
+  /**
+   * Create a new Article
+   *
+   * @param title the title of the article
+   * @param url the url of the article
+   * @param explanation the explanation of the article
+   * @param email the email of the person submitting the article
+   * @param dateAdded the date the article was added
+   * @return the saved Article
+   */
+  @Operation(summary = "Create a new article")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public Articles postArticle(
+      @Parameter(name = "title") @RequestParam String title,
+      @Parameter(name = "url") @RequestParam String url,
+      @Parameter(name = "explanation") @RequestParam String explanation,
+      @Parameter(name = "email") @RequestParam String email,
+      @Parameter(
+              name = "dateAdded",
+              description =
+                  "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("dateAdded")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateAdded) {
+
+    log.info("dateAdded={}", dateAdded);
+
+    Articles article = new Articles();
+    article.setTitle(title);
+    article.setUrl(url);
+    article.setExplanation(explanation);
+    article.setEmail(email);
+    article.setDateAdded(dateAdded);
+
+    Articles savedArticle = articlesRepository.save(article);
+
+    return savedArticle;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
@@ -1,0 +1,28 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity(name = "articles")
+public class Articles {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String title;
+  private String url;
+  private String explanation;
+  private String email;
+  private LocalDateTime dateAdded;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
@@ -1,0 +1,8 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.Articles;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ArticlesRepository extends CrudRepository<Articles, Long> {}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
@@ -2,7 +2,9 @@ package edu.ucsb.cs156.example.repositories;
 
 import edu.ucsb.cs156.example.entities.Articles;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@RepositoryRestResource(exported = false)
 public interface ArticlesRepository extends CrudRepository<Articles, Long> {}

--- a/src/main/resources/db/migration/changes/Articles.json
+++ b/src/main/resources/db/migration/changes/Articles.json
@@ -1,0 +1,87 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "Articles-1",
+          "author": "taedonreth",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "ARTICLES"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "ARTICLES_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "TITLE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "URL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "DATE_ADDED",
+                      "type": "TIMESTAMP"
+                    }
+                  }
+                ],
+                "tableName": "ARTICLES"
+              }
+            }
+          ]
+        }
+    }
+]}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -1,0 +1,173 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = ArticlesController.class)
+@Import(TestConfig.class)
+public class ArticlesControllerTests extends ControllerTestCase {
+
+  @MockitoBean ArticlesRepository articlesRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for /api/Articles/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc.perform(get("/api/Articles/all")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/Articles/all")).andExpect(status().is(200));
+  }
+
+  // Authorization tests for /api/Articles/post
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/Articles/post")
+                .param("title", "Using testing-playground with React Testing Library")
+                .param(
+                    "url",
+                    "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+                .param("explanation", "Helpful when we get to front end development")
+                .param("email", "phtcon@ucsb.edu")
+                .param("dateAdded", "2022-04-20T00:00:00")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/Articles/post")
+                .param("title", "Using testing-playground with React Testing Library")
+                .param(
+                    "url",
+                    "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+                .param("explanation", "Helpful when we get to front end development")
+                .param("email", "phtcon@ucsb.edu")
+                .param("dateAdded", "2022-04-20T00:00:00")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_articles() throws Exception {
+
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T00:00:00");
+
+    Articles article1 =
+        Articles.builder()
+            .id(1L)
+            .title("Using testing-playground with React Testing Library")
+            .url(
+                "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+            .explanation("Helpful when we get to front end development")
+            .email("phtcon@ucsb.edu")
+            .dateAdded(ldt1)
+            .build();
+
+    LocalDateTime ldt2 = LocalDateTime.parse("2022-04-19T00:00:00");
+
+    Articles article2 =
+        Articles.builder()
+            .id(2L)
+            .title("Handy Spring Utility Classes")
+            .url(
+                "https://twitter.com/maciejwalkowiak/status/1511736828369719300?t=gGXpmBH4y4eY9OBSUInZEg&s=09")
+            .explanation("A lot of really useful classes are built into Spring")
+            .email("phtcon@ucsb.edu")
+            .dateAdded(ldt2)
+            .build();
+
+    ArrayList<Articles> expectedArticles = new ArrayList<>();
+    expectedArticles.addAll(Arrays.asList(article1, article2));
+
+    when(articlesRepository.findAll()).thenReturn(expectedArticles);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/Articles/all")).andExpect(status().isOk()).andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedArticles);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_article() throws Exception {
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2022-04-20T00:00:00");
+
+    Articles article =
+        Articles.builder()
+            .title("Using testing-playground with React Testing Library")
+            .url(
+                "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+            .explanation("Helpful when we get to front end development")
+            .email("phtcon@ucsb.edu")
+            .dateAdded(ldt)
+            .build();
+
+    when(articlesRepository.save(eq(article))).thenReturn(article);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/Articles/post")
+                    .param("title", "Using testing-playground with React Testing Library")
+                    .param(
+                        "url",
+                        "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+                    .param("explanation", "Helpful when we get to front end development")
+                    .param("email", "phtcon@ucsb.edu")
+                    .param("dateAdded", "2022-04-20T00:00:00")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).save(article);
+    String expectedJson = mapper.writeValueAsString(article);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
Adds `ArticlesController` exposing `GET /api/Articles/all` and `POST /api/Articles/post`, with full Jacoco line coverage and 100% Pitest mutation coverage. Also marks `ArticlesRepository` non-exported to suppress auto-generated `/api/rest/v1/articleses` endpoints.

Verified end-to-end on localhost (H2) and Dokku (Postgres) via Swagger.

Closes #39 