### PR TITLE
Add DELETE endpoint for Articles

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -6,6 +6,7 @@ import edu.ucsb.cs156.example.repositories.ArticlesRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -93,6 +96,35 @@ public class ArticlesController extends ApiController {
         articlesRepository
             .findById(id)
             .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+    return article;
+  }
+
+  /**
+   * Update a single Article
+   *
+   * @param id id of the article to update
+   * @param incoming the new article values
+   * @return the updated article object
+   */
+  @Operation(summary = "Update a single article")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public Articles updateArticle(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid Articles incoming) {
+
+    Articles article =
+        articlesRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+    article.setTitle(incoming.getTitle());
+    article.setUrl(incoming.getUrl());
+    article.setExplanation(incoming.getExplanation());
+    article.setEmail(incoming.getEmail());
+    article.setDateAdded(incoming.getDateAdded());
+
+    articlesRepository.save(article);
 
     return article;
   }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -127,5 +128,24 @@ public class ArticlesController extends ApiController {
     articlesRepository.save(article);
 
     return article;
+  }
+
+  /**
+   * Delete an Article
+   *
+   * @param id the id of the article to delete
+   * @return a message indicating the article was deleted
+   */
+  @Operation(summary = "Delete an article")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteArticle(@Parameter(name = "id") @RequestParam Long id) {
+    Articles article =
+        articlesRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+    articlesRepository.delete(article);
+    return genericMessage("Articles with id %s deleted".formatted(id));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edu.ucsb.cs156.example.ControllerTestCase;
@@ -23,6 +24,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -233,5 +235,157 @@ public class ArticlesControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
     assertEquals("Articles with id 7 not found", json.get("message"));
+  }
+
+  // Tests for PUT /api/Articles?id=...
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_article() throws Exception {
+    // arrange
+    LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T00:00:00");
+    LocalDateTime ldt2 = LocalDateTime.parse("2023-01-15T12:30:00");
+
+    Articles originalArticle =
+        Articles.builder()
+            .id(67L)
+            .title("Using testing-playground with React Testing Library")
+            .url(
+                "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+            .explanation("Helpful when we get to front end development")
+            .email("phtcon@ucsb.edu")
+            .dateAdded(ldt1)
+            .build();
+
+    Articles editedArticle =
+        Articles.builder()
+            .id(67L)
+            .title("Handy Spring Utility Classes")
+            .url(
+                "https://twitter.com/maciejwalkowiak/status/1511736828369719300?t=gh3gS4ZbXf4ZjazoLLqHFA&s=19")
+            .explanation("A lot of really useful classes are built into Spring")
+            .email("phill@ucsb.edu")
+            .dateAdded(ldt2)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(editedArticle);
+
+    when(articlesRepository.findById(eq(67L))).thenReturn(Optional.of(originalArticle));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/Articles")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(eq(67L));
+    verify(articlesRepository, times(1)).save(editedArticle);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_article_that_does_not_exist() throws Exception {
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2023-01-15T12:30:00");
+
+    Articles editedArticle =
+        Articles.builder()
+            .id(67L)
+            .title("Handy Spring Utility Classes")
+            .url(
+                "https://twitter.com/maciejwalkowiak/status/1511736828369719300?t=gh3gS4ZbXf4ZjazoLLqHFA&s=19")
+            .explanation("A lot of really useful classes are built into Spring")
+            .email("phill@ucsb.edu")
+            .dateAdded(ldt)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(editedArticle);
+
+    when(articlesRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/Articles")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(eq(67L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Articles with id 67 not found", json.get("message"));
+  }
+
+  @Test
+  public void logged_out_users_cannot_put() throws Exception {
+    LocalDateTime ldt = LocalDateTime.parse("2023-01-15T12:30:00");
+
+    Articles editedArticle =
+        Articles.builder()
+            .id(67L)
+            .title("Handy Spring Utility Classes")
+            .url(
+                "https://twitter.com/maciejwalkowiak/status/1511736828369719300?t=gh3gS4ZbXf4ZjazoLLqHFA&s=19")
+            .explanation("A lot of really useful classes are built into Spring")
+            .email("phill@ucsb.edu")
+            .dateAdded(ldt)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(editedArticle);
+
+    mockMvc
+        .perform(
+            put("/api/Articles")
+                .param("id", "67")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_put() throws Exception {
+    LocalDateTime ldt = LocalDateTime.parse("2023-01-15T12:30:00");
+
+    Articles editedArticle =
+        Articles.builder()
+            .id(67L)
+            .title("Handy Spring Utility Classes")
+            .url(
+                "https://twitter.com/maciejwalkowiak/status/1511736828369719300?t=gh3gS4ZbXf4ZjazoLLqHFA&s=19")
+            .explanation("A lot of really useful classes are built into Spring")
+            .email("phill@ucsb.edu")
+            .dateAdded(ldt)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(editedArticle);
+
+    mockMvc
+        .perform(
+            put("/api/Articles")
+                .param("id", "67")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+        .andExpect(status().is(403));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -1,11 +1,13 @@
 package edu.ucsb.cs156.example.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -386,6 +388,77 @@ public class ArticlesControllerTests extends ControllerTestCase {
                 .characterEncoding("utf-8")
                 .content(requestBody)
                 .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  // Tests for DELETE /api/Articles?id=...
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_an_article() throws Exception {
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2022-04-20T00:00:00");
+
+    Articles article =
+        Articles.builder()
+            .id(15L)
+            .title("Using testing-playground with React Testing Library")
+            .url(
+                "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7")
+            .explanation("Helpful when we get to front end development")
+            .email("phtcon@ucsb.edu")
+            .dateAdded(ldt)
+            .build();
+
+    when(articlesRepository.findById(eq(15L))).thenReturn(Optional.of(article));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/Articles").param("id", "15").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(15L);
+    verify(articlesRepository, times(1)).delete(any());
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Articles with id 15 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_tries_to_delete_non_existent_article_and_gets_right_error_message()
+      throws Exception {
+    // arrange
+    when(articlesRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/Articles").param("id", "15").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(articlesRepository, times(1)).findById(15L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Articles with id 15 not found", json.get("message"));
+  }
+
+  @Test
+  public void logged_out_users_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/Articles").param("id", "15").with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/Articles").param("id", "15").with(csrf()))
         .andExpect(status().is(403));
   }
 }


### PR DESCRIPTION
Adds `DELETE /api/Articles?id=<id>` (admin-only) — deletes the row on hit and returns 200 with `"Articles with id <id> deleted"`, or 404 with `"Articles with id <id> not found"` on miss. 

Verified in Swagger on localhost (H2) and Dokku (Postgres). Full Jacoco line coverage and 100% Pitest mutation coverage on the controller.

Closes #42 